### PR TITLE
change os.rename to shutil.move in save()

### DIFF
--- a/kineticstoolkit/loadsave.py
+++ b/kineticstoolkit/loadsave.py
@@ -161,7 +161,7 @@ def save(filename: str, variable: Any) -> None:
         json.dump(variable, fid, cls=CustomEncoder, indent='\t')
 
     shutil.make_archive(temp_folder, 'zip', temp_folder)
-    os.rename(temp_folder + '.zip', filename)
+    shutil.move(temp_folder + '.zip', filename)
     shutil.rmtree(temp_folder)
 
 


### PR DESCRIPTION
should fix #68 
using `shutil.move` instead of `os.rename` in `save()` allowed me to save to an external drive. Followed this post on stack overflow: 
https://stackoverflow.com/questions/21116510/python-oserror-winerror-17-the-system-cannot-move-the-file-to-a-different-d